### PR TITLE
fix(windows): repair MSI setup pipeline and Python input sidecar lifecycle

### DIFF
--- a/electron-main.js
+++ b/electron-main.js
@@ -623,11 +623,24 @@ async function createWindow() {
     const fs = require('fs');
 
     if (os.platform() === 'win32') {
-      // WINDOWS: Run the PowerShell setup script natively as Administrator
-      const scriptPath = path.join(__dirname, 'bin', 'windows_setup.ps1');
-      const psCommand = `Start-Process powershell -ArgumentList '-ExecutionPolicy Bypass -File ""${scriptPath}""' -Verb RunAs`;
+      // WINDOWS: Run the PowerShell setup script natively as Administrator.
+      // If running from an MSI/electron-builder build, extraResources places 'bin'
+      // in resourcesPath (outside app.asar). An elevated PowerShell cannot read
+      // files inside app.asar, so redirect to the unpacked copy — same as Linux.
+      let scriptPath = path.join(__dirname, 'bin', 'windows_setup.ps1');
+      if (__dirname.includes('app.asar')) {
+        scriptPath = path.join(process.resourcesPath, 'bin', 'windows_setup.ps1');
+      }
+      if (!fs.existsSync(scriptPath)) {
+        console.error('[Setup] windows_setup.ps1 not found at', scriptPath);
+        event.reply('setup-failed', 'Setup script not found: ' + scriptPath);
+        return;
+      }
+      // -Wait makes the outer process block until the elevated script window
+      // closes, so setup-success reflects actual completion, not mere launch.
+      const psCommand = `Start-Process powershell -ArgumentList '-ExecutionPolicy Bypass -File ""${scriptPath}""' -Verb RunAs -Wait`;
 
-      exec(`powershell -Command "${psCommand}"`, (error) => {
+      exec(`powershell -NoProfile -Command "${psCommand}"`, (error) => {
         if (error) {
           console.error('[Setup] Windows setup failed:', error.message);
           event.reply('setup-failed', error.message);

--- a/src/sidecar/input_backends/InputOrchestrator.js
+++ b/src/sidecar/input_backends/InputOrchestrator.js
@@ -180,7 +180,14 @@ function init(screenWidth, screenHeight) {
     }
 
     const pythonCmd = isWin ? 'python' : 'python3';
-    _pythonProc = spawn(pythonCmd, [pythonScript], { stdio: ['pipe', 'pipe', 'inherit'] });
+    const spawnOpts = { stdio: ['pipe', 'pipe', 'pipe'] };
+    if (isWin) spawnOpts.windowsHide = true;
+    _pythonProc = spawn(pythonCmd, [pythonScript], spawnOpts);
+
+    _pythonProc.stderr.on('data', (chunk) => {
+        const s = chunk.toString('utf8').trim();
+        if (s) console.error('[input][python stderr]', s);
+    });
 
     // Parse stdout from the Python sidecar as JSON lines.
     // The sidecar emits structured { "type": "...", "message": "..." } payloads

--- a/src/sidecar/input_backends/windows_vigem.py
+++ b/src/sidecar/input_backends/windows_vigem.py
@@ -367,8 +367,12 @@ def _handle_gamepad(msg: dict):
         try:
             gp = vg.VX360Gamepad()
             
+            # Capture pad_id in a closure — vgamepad 0.1.0's register_notification()
+            # does not accept a user_data kwarg, but still passes user_data=None to
+            # the callback, so we ignore the callback's user_data and use our own.
+            _captured_pad_id = pad_id
             def _on_vibration(client, target, large_motor, small_motor, led_number, user_data):
-                vid = str(user_data).split('_')[0] if "_" in str(user_data) else str(user_data)
+                vid = str(_captured_pad_id).split('_')[0] if "_" in str(_captured_pad_id) else str(_captured_pad_id)
                 _emit({
                     "type": "rumble",
                     "viewerId": vid,
@@ -377,7 +381,7 @@ def _handle_gamepad(msg: dict):
                     "duration": 250
                 })
 
-            gp.register_notification(callback_function=_on_vibration, user_data=pad_id)
+            gp.register_notification(callback_function=_on_vibration)
 
             gp.update()  # Send an initial neutral state to register with ViGEmBus
             devices[pad_id] = gp


### PR DESCRIPTION
## Summary

The Windows host has been broken since at least v3.0.1 — the bundled MSI cannot complete first-run setup, and even when setup is run manually, the Python input sidecar dies immediately and no virtual gamepad is created. This PR fixes the 3 bugs in the chain. All three are code bugs, not driver/version issues.

PR #15 fixed in-game Windows issues (WebCodecs, KBM emulation, latency). These fixes target a different layer: the **setup/installation pipeline** and the **sidecar process lifecycle**.

## The bug chain

Each bug masks the next — you can't reach bug #4 without fixing bugs #1–#3 first. This is why the Windows path was never exercised end-to-end.

### Bug 1 — `electron-main.js`: Setup button flashes a window that closes instantly
**Root cause:** The `run-setup` IPC handler builds the script path from `__dirname`, which inside an electron-builder MSI/AppImage points at `app.asar`. An elevated PowerShell spawned via `Start-Process -Verb RunAs` runs outside Electron's asar hook and sees `app.asar` as a single opaque file — so `-File "...\app.asar\bin\windows_setup.ps1"` fails instantly with "file not found". The Linux branch already redirects to `process.resourcesPath` when `__dirname` includes `app.asar`; the Windows branch was missing the same guard.

**Fix:** Redirect to `process.resourcesPath\bin\` when inside `app.asar`. Also add `-Wait` so `setup-success` fires after the script finishes (not on mere launch — previously the app reported fake success even when the script crashed on line 1), `-NoProfile`, and an `fs.existsSync` guard.

### Bug 2 — `InputOrchestrator.js`: Python sidecar exits with code `0xC000013A` immediately after "ready"
**Root cause:** `spawn(pythonCmd, [script], { stdio: ['pipe', 'pipe', 'inherit'] })` makes Python inherit Electron's stderr handle. Since Electron launched from an MSI is a GUI app with no console, Windows creates a temporary console for the Python process and tears it down shortly after — delivering a `CTRL_CLOSE_EVENT` that kills Python with `STATUS_CONTROL_C_EXIT` (exit code 3221225786 / `0xC000013A`). The sidecar logs "Sidecar ready" + "UDP listening on port XXXX", then dies. Every subsequent gamepad packet is silently dropped by the `if (!_bridge && !_pythonProc) return;` guard, so the Input Visualizer shows zero activity. Linux is unaffected (different console-control model).

**Fix:** Use `stdio: ['pipe', 'pipe', 'pipe']` + `windowsHide: true` + a stderr listener that forwards to `console.error`.

### Bug 3 — `windows_vigem.py`: `VX360Gamepad.register_notification() got an unexpected keyword argument 'user_data'`
**Root cause:** `gp.register_notification(callback_function=_on_vibration, user_data=pad_id)` passes `user_data` as a kwarg, but `vgamepad`'s signature is `register_notification(self, callback_function)` — it never accepted `user_data`. This raises `TypeError` on every virtual gamepad creation, which the sidecar catches and emits as `VIGEMBUS_CREATE_FAILED`. No viewer's gamepad ever materializes. This fails on every vgamepad version, not just 0.1.0.

**Fix:** Capture `pad_id` in a closure (`_captured_pad_id`) instead of passing it as a kwarg. The callback still receives `user_data=None` from the C side, but we use the closure value instead.

## How to test

> **These bugs only reproduce in the packaged MSI — `npm start` / `npm run dev` will NOT catch them**, because in dev mode `__dirname` is a real folder (no asar), Electron runs in a terminal (has a console), and bug #3 requires a viewer connection.

### Recommended testing workflow

Since the project has no CI or contribution guide, here's a proposed process for testing Windows changes that only manifest in packaged builds:

1. **Build a test MSI without auto-publishing** (the `dist:win` script uses `--publish always` which would push to GitHub releases — override it):
   ```bash
   npm install
   npx electron-builder --win --publish never
   # Output: dist/NearsecTogether Setup 3.0.1.exe
   ```

2. **Test on a clean Windows machine** (or VM without ViGEmBus/Python/Sunshine pre-installed, to avoid false positives — my host had ViGEmBus from Sunshine, which masked the corrupted `ViGEmBus_Setup.exe`):
   - Install the test MSI
   - Open the app → click "Setup" on the dashboard
   - Verify: UAC prompt → PowerShell window stays open → installs ViGEmBus + Python + pip packages → ends with "Done! Press Enter to close"
   - Verify: the green "Finished" breadcrumb appears AFTER the window closes (not instantly)

3. **Test the input pipeline end-to-end:**
   - Quit the app fully (tray → Quit), reopen
   - Connect from a viewer device (mobile/laptop)
   - Check Settings → Input Visualizer: should show live button/axis values
   - Check `joy.cpl`: should show a virtual "Controller (Xbox 360 For Windows)" when the viewer presses buttons
   - Check `%APPDATA%\NearsecTogether\latest.log` for:
     ```
     [input][python] Sidecar ready: Windows vgamepad + pyautogui backend initialized
     [input][python] UDP listening on port XXXX
     [input][python] Created virtual gamepad for slot: <viewerId>_0
     ```
   - **No** `Python sidecar exited (code 3221225786)` line should appear

4. **Publish test binaries for the maintainer** (optional): create a pre-release on the fork with the built MSI so they can verify without building:
   ```bash
   gh release create v3.0.1-winfix-test "dist/NearsecTogether Setup 3.0.1.exe" --repo sebastiannicolas-analytia/NearsecTogether --prerelease --notes "Test build for PR #N — Windows setup/input fixes"
   ```

### Test matrix

| Scenario | Before this PR | After this PR |
|---|---|---|
| Click Setup from dashboard | Window flashes, closes instantly, fake green "Finished" | UAC → PowerShell runs full setup → real green "Finished" |
| Sidecar lifecycle | Logs "ready" then exits `0xC000013A` | Stays alive for full session |
| Viewer gamepad → host | Input Visualizer flat, no virtual controller in `joy.cpl` | Visualizer shows live data, virtual Xbox 360 controller appears |
| Dev mode (`npm run electron`) | Works (bugs masked by console + real folder) | Still works (no regression) |

## Verification performed

Tested on Windows 11 with the v3.0.1 MSI installed from `C:\Program Files\NearsecTogether`:
- ✅ Setup script now launches from the correct `resources\bin\` path
- ✅ ViGEmBus driver confirmed present (`Nefarius Virtual Gamepad Emulation Bus`, Status OK)
- ✅ Python 3.11.8 + `vgamepad` 0.1.0 + `pyautogui` installed
- ✅ `python -c "import vgamepad; vg.VX360Gamepad().update()"` succeeds
- ✅ Sidecar stays alive after "ready" (no `0xC000013A` exit)
- ✅ Viewer gamepad packets create a virtual Xbox 360 controller
- ✅ Input Visualizer shows live button/axis data

## Out of scope (follow-up issues)

1. **`bin/ViGEmBus_Setup.exe` is corrupted in the repo** — 2.1M bytes were replaced with U+FFFD (UTF-8 replacement character), likely from being committed as text without a `.gitattributes` binary rule. SHA256 `06EDC3A7…` does not match any official nefarius release. This should be replaced with a valid binary and a `.gitattributes` added to prevent recurrence. I did NOT touch this file in this PR.

2. **`windows_setup.ps1` ViGEmBus detection false-negative** — the script checks `Get-PnpDevice -FriendlyName 'ViGEmBus Device'` but the actual device name is `'Nefarius Virtual Gamepad Emulation Bus'`. If ViGEmBus is already installed (e.g. via Sunshine), the script tries to reinstall from the corrupted exe and fails. Minor, but worth fixing.

3. **`dist:win` uses `--publish always`** — this auto-publishes to GitHub releases on every build, which is dangerous for contributors. Consider splitting into `dist:win` (`--publish never`) and `release:win` (`--publish always`).